### PR TITLE
Adding explicit dependency to VirtualCategories (because of custom Action models)

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -19,6 +19,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Smile_ElasticsuiteTargetRule" setup_version="1.0.0">
         <sequence>
+            <module name="Smile_ElasticsuiteVirtualCategory" />
             <module name="Smile_ElasticsuiteCatalogRule" />
             <module name="Magento_TargetRule" />
         </sequence>


### PR DESCRIPTION
Both 
- \Smile\ElasticsuiteTargetRule\Model\Actions\Condition\Product\Attributes
- \Smile\ElasticsuiteTargetRule\Model\Actions\Condition\Product\Special\Price 
directly extend \Smile\ElasticsuiteVirtualCategory\Model\Rule\Condition\Product
-> Added the explicit dependency in module.xml
