### PR TITLE
Percolate request - keep ES6 compatibility

### DIFF
--- a/Model/Percolator.php
+++ b/Model/Percolator.php
@@ -120,12 +120,9 @@ class Percolator
         $percolatorQuery['percolate'] = [
             'field' => '_targetrule.query',
             'index' => $containerConfig->getIndexName(),
+            'type' => '_doc',
             'id'    => $productId,
         ];
-
-        if (method_exists($containerConfig, 'getTypeName')) {
-            $percolatorQuery['percolate']['type'] = $containerConfig->getTypeName();
-        }
 
         $percolatorFilter['query']['bool']['must'] = [
             ['term' => ['_targetrule.percolator_type' => PercolatorData::PERCOLATOR_TYPE]],


### PR DESCRIPTION
Changes the approach taken in https://github.com/Smile-SA/magento2-module-elasticsuite-targetrule/pull/13/commits/ae78b24974f8031d7c81e9794159e54886266821 to keep the module compatible with ES7 **and** ES6 as is Elasticsuite 2.9.x
Note that this will throw deprecation warnings.

